### PR TITLE
change setup instructions and index page text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ To install the app dependencies clone the repo then CD to the directory, then ru
 
     bundle install
 
+To fetch the govuk_frontend_toolkit run the following command:
+
+    git submodule init
+
+To update the govuk_frontend_toolkit run the following command:
+
+    git submodule update
+
 Then starting the app with:
 
     jekyll s

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ This is an MVP of an attempt to do the following:
 1. Provide a single, canonical, up to date place for assessment questions
 2. Present them in a nicer way than the Microsoft Excel version does.
 
-Click on the links above to see the prompts for each stage.
+Click on the links below to see the prompts for both the previous and current versions of the assessment prompts.
 
 ### Versions:
 


### PR DESCRIPTION
instructions added to readme to download the 
govuk_frontend_toolkit module. the index page
copy was updated to reflect the position of
the links on the page.